### PR TITLE
suggestions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,8 +8,3 @@ ignore =
 
 exclude =
     .venv/**
-
-per-file-ignores =
-    # __init__.py files are allowed to have unused imports and lines-too-long
-    */__init__.py:F401
-    */**/**/__init__.py:F401,E501

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cached_path
 
-A file utility library for downloading, caching, and accessing dataset files.
+A file utility library that provides a unified, simple interface for accessing both local and remote files.
+This can be used behind other APIs that need to access files agnostic to where they are located.
 
 <p align="center">
     <a href="https://github.com/allenai/cached_path/actions">
@@ -28,7 +29,7 @@ pip install cached_path
 
 ## Usage
 
-Given something that might be a URL or local path, `get_cached_path` determines which.
+Given something that might be a URL or local path, `cached_path` determines which.
 If it's a remote resource, it downloads the file and caches it, and
 then returns the path to the cached file. If it's already a local path,
 it makes sure the file exists and returns the path.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ pip install cached_path
 
 ## Usage
 
+```python
+from cached_path import cached_path
+```
+
 Given something that might be a URL or local path, `cached_path` determines which.
 If it's a remote resource, it downloads the file and caches it, and
 then returns the path to the cached file. If it's already a local path,
@@ -41,7 +45,7 @@ For example, to download the PyTorch weights for the model `epwalsh/bert-xsmall-
 on HuggingFace, you could do:
 
 ```python
-get_cached_path("hf://epwalsh/bert-xsmall-dummy/pytorch_model.bin")
+cached_path("hf://epwalsh/bert-xsmall-dummy/pytorch_model.bin")
 ```
 
 For paths or URLs that point to a tarfile or zipfile, you can also add a path
@@ -50,7 +54,7 @@ be automatically extracted (provided you set `extract_archive` to `True`),
 returning the local path to the specific file. For example:
 
 ```python
-get_cached_path("model.tar.gz!weights.th", extract_archive=True)
+cached_path("model.tar.gz!weights.th", extract_archive=True)
 ```
 
 ## Team

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -188,7 +188,7 @@ def cached_path(
     on HuggingFace, you could do:
 
     ```python
-    get_cached_path("hf://epwalsh/bert-xsmall-dummy/pytorch_model.bin")
+    cached_path("hf://epwalsh/bert-xsmall-dummy/pytorch_model.bin")
     ```
 
     For paths or URLs that point to a tarfile or zipfile, you can also add a path
@@ -197,7 +197,7 @@ def cached_path(
     returning the local path to the specific file. For example:
 
     ```python
-    get_cached_path("model.tar.gz!weights.th", extract_archive=True)
+    cached_path("model.tar.gz!weights.th", extract_archive=True)
     ```
 
     # Parameters
@@ -236,7 +236,7 @@ def cached_path(
         file_name = url_or_filename[exclamation_index + 1 :]
 
         # Call 'cached_path' recursively now to get the local path to the archive itself.
-        cached_archive_path = get_cached_path(archive_path, cache_dir, True, force_extract)
+        cached_archive_path = cached_path(archive_path, cache_dir, True, force_extract)
         if not os.path.isdir(cached_archive_path):
             raise ValueError(
                 f"{url_or_filename} uses the ! syntax, but does not specify an archive file."

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -503,7 +503,7 @@ def _http_get(url: str, temp_file: IO) -> None:
         req.raise_for_status()
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
-        progress = Tqdm.tqdm(unit="B", total=total, desc="downloading")
+        progress = Tqdm.tqdm(unit="B", unit_scale=True, total=total, desc="downloading")
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 progress.update(len(chunk))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,3 +18,6 @@ codecov
 twine>=1.11.0
 setuptools
 wheel
+
+# Mocking HTTP responses
+responses==0.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-filelock==3.0.12
-boto3==1.18.35
-google-cloud-storage==1.42.0
+requests>=2.0,<3.0
+filelock>=3.0,<4.0
+boto3>=1.0,<2.0
+google-cloud-storage>=1.0,<2.0
 overrides==3.1.0
-huggingface-hub==0.0.12
-responses==0.13.3
+huggingface-hub>=0.0.12,<0.1.0


### PR DESCRIPTION
- Adds `requests` to requirements.txt since it's a direct requirement.
- Moves `responses` to dev-requirements.txt (this is only needed for testing).
- Pins all dependencies to a reasonable range based on semantic versioning. Downstream libraries could always use tighter pins if needed.
- Renames `get_cached_path` back to the original `cached_path`. I think it's better to keep the original name.
- Changes the `CACHE_DIRECTORY` to `~/.cache/cached_path`. The `~/.cache` directory is the standard place to put this kind of thing.

Let me know what you think.