### PR TITLE
Use tqdm with 1024 instead of 1000 unit scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The download progress bar uses 1024 instead of 1000 as the unit scale.
+
 ## [v0.1.0](https://github.com/allenai/cached_path/releases/tag/v0.1.0) - 2021-09-09
 
 ### Added

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -503,7 +503,7 @@ def _http_get(url: str, temp_file: IO) -> None:
         req.raise_for_status()
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
-        progress = Tqdm.tqdm(unit="B", unit_scale=True, total=total, desc="downloading")
+        progress = Tqdm.tqdm(unit="iB", unit_scale=True, unit_divisor=1024, total=total, desc="downloading")
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 progress.update(len(chunk))

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -503,7 +503,9 @@ def _http_get(url: str, temp_file: IO) -> None:
         req.raise_for_status()
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
-        progress = Tqdm.tqdm(unit="iB", unit_scale=True, unit_divisor=1024, total=total, desc="downloading")
+        progress = Tqdm.tqdm(
+            unit="iB", unit_scale=True, unit_divisor=1024, total=total, desc="downloading"
+        )
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 progress.update(len(chunk))


### PR DESCRIPTION
Change the `tqdm` progress bar so that the scales are multiple of 1024 instead of 1000. Also use the unit "iB" as in "GiB" to make it unambiguous for the user (see [Binary prefix](https://en.wikipedia.org/wiki/Binary_prefix)).