### PR TITLE
change return type to "Path", add doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
           - name: Test
             run: |
-              pytest -v --color=yes tests/
+              pytest -v --color=yes --doctest-modules --doctest-glob='*.md'
 
           - name: Build
             run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Python >= 3.7 now required.
+- `cached_path()` now returns a `Path` instead of a `str`.
 
 ## [v1.0.2](https://github.com/allenai/cached_path/releases/tag/v1.0.2) - 2021-12-23
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY : docs
 docs :
 	rm -rf docs/build/
-	sphinx-autobuild -b html --watch tango/ --watch examples/ docs/source/ docs/build/
+	sphinx-autobuild -b html --watch cached_path/ docs/source/ docs/build/

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -10,10 +10,10 @@ and ``hf`` for HuggingFace Hub. See :func:`cached_path.cached_path()` for more d
 You can also extend **cached-path** to support other schemes with :func:`add_scheme_client()`.
 """
 
-from cached_path._cached_path import cached_path
-from cached_path.common import file_friendly_logging, get_cache_dir, set_cache_dir
-from cached_path.schemes import SchemeClient, add_scheme_client
-from cached_path.util import (
+from ._cached_path import cached_path
+from .common import file_friendly_logging, get_cache_dir, set_cache_dir
+from .schemes import SchemeClient, add_scheme_client
+from .util import (
     check_tarfile,
     filename_to_url,
     find_latest_cached,

--- a/cached_path/cache_file.py
+++ b/cached_path/cache_file.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from cached_path.common import PathOrStr
+from .common import PathOrStr
 
 logger = logging.getLogger(__name__)
 

--- a/cached_path/common.py
+++ b/cached_path/common.py
@@ -46,11 +46,11 @@ def set_cache_dir(cache_dir: PathOrStr) -> None:
     CACHE_DIRECTORY = Path(cache_dir)
 
 
-def get_cache_dir() -> PathOrStr:
+def get_cache_dir() -> Path:
     """
     Get the global default cache directory.
     """
-    return CACHE_DIRECTORY
+    return Path(CACHE_DIRECTORY)
 
 
 def file_friendly_logging(on: bool = True) -> None:

--- a/cached_path/file_lock.py
+++ b/cached_path/file_lock.py
@@ -4,7 +4,7 @@ import warnings
 from filelock import AcquireReturnProxy
 from filelock import FileLock as _FileLock
 
-from cached_path.common import PathOrStr
+from .common import PathOrStr
 
 
 class FileLock(_FileLock):

--- a/cached_path/meta.py
+++ b/cached_path/meta.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Optional, Set
 
-from cached_path.common import PathOrStr
+from .common import PathOrStr
 
 
 @dataclass

--- a/cached_path/testing.py
+++ b/cached_path/testing.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from cached_path.common import get_cache_dir, set_cache_dir
+from .common import get_cache_dir, set_cache_dir
 
 
 class BaseTestClass:

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -6,9 +6,15 @@ FAQ
 No, not at the moment. But you can still benefit by calling {func}`~cached_path.cached_path()` concurrently
 using {func}`asyncio.to_thread()`. For example:
 
-```python
->>> import asyncio
+```{testsetup}
+>>> import sys, pytest, asyncio
 >>> from cached_path import cached_path
+>>> if sys.version_info < (3, 9):
+...     pytest.skip("This doctest requires Python >= 3.9")
+>>>
+```
+
+```python
 >>> async def main():
 ...     print("Downloading files...")
 ...     await asyncio.gather(
@@ -17,6 +23,7 @@ using {func}`asyncio.to_thread()`. For example:
 ...         asyncio.to_thread(cached_path, "https://github.com/allenai/cached_path/blob/main/requirements.txt"),
 ...     )
 ...     print("Finished all downloads")
+...
 >>> asyncio.run(main())
 Downloading files...
 Finished all downloads

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -1,0 +1,24 @@
+FAQ
+===
+
+## Does `cached_path` have an async interface?
+
+No, not at the moment. But you can still benefit by calling {func}`~cached_path.cached_path()` concurrently
+using {func}`asyncio.to_thread()`. For example:
+
+```python
+>>> import asyncio
+>>> from cached_path import cached_path
+>>> async def main():
+...     print("Downloading files...")
+...     await asyncio.gather(
+...         asyncio.to_thread(cached_path, "https://github.com/allenai/cached_path/blob/main/README.md"),
+...         asyncio.to_thread(cached_path, "https://github.com/allenai/cached_path/blob/main/setup.py"),
+...         asyncio.to_thread(cached_path, "https://github.com/allenai/cached_path/blob/main/requirements.txt"),
+...     )
+...     print("Finished all downloads")
+>>> asyncio.run(main())
+Downloading files...
+Finished all downloads
+>>>
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,6 +11,7 @@
 
 installation
 overview
+faq
 ```
 
 ```{toctree}

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -3,6 +3,11 @@ Overview
 
 The main functionality of **cached-path** is provided by the function {func}`~cached_path.cached_path()`.
 
+```{testsetup}
+>>> from cached_path import cached_path
+>>>
+```
+
 ## Basic usage
 
 {func}`~cached_path.cached_path()` has a single positional argument that is either the path to a local file or the URL of a remote resource.
@@ -11,7 +16,6 @@ For example, assuming the file `README.md` exists locally, the returned by is ju
 the same path that was provided:
 
 ```python
->>> from cached_path import cached_path
 >>> print(cached_path("README.md"))
 README.md
 >>>
@@ -20,9 +24,9 @@ README.md
 But for remote resources, the resource will be downloaded and cached to the cache directory:
 
 ```python
->>> from cached_path import get_cache_dir
 >>> path = cached_path("https://github.com/allenai/cached_path/blob/main/README.md")
 >>> assert path.is_file()
+>>> from cached_path import get_cache_dir
 >>> assert path.parent == get_cache_dir()
 >>>
 ```

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -3,10 +3,6 @@ Overview
 
 The main functionality of **cached-path** is provided by the function {func}`~cached_path.cached_path()`.
 
-```python
-from cached_path import cached_path
-```
-
 ## Basic usage
 
 {func}`~cached_path.cached_path()` has a single positional argument that is either the path to a local file or the URL of a remote resource.
@@ -15,26 +11,27 @@ For example, assuming the file `README.md` exists locally, the returned by is ju
 the same path that was provided:
 
 ```python
-assert cached_path("README.md") == "README.md"
+>>> from cached_path import cached_path
+>>> print(cached_path("README.md"))
+README.md
+>>>
 ```
 
 But for remote resources, the resource will be downloaded and cached to the cache directory:
 
 ```python
-path = cached_path("https://github.com/allenai/cached_path/blob/main/README.md")
-assert os.path.exists(path)
-assert os.path.split(path)[0] == os.path.expanduser("~/.cache/cached_path")
+>>> from cached_path import get_cache_dir
+>>> path = cached_path("https://github.com/allenai/cached_path/blob/main/README.md")
+>>> assert path.is_file()
+>>> assert path.parent == get_cache_dir()
+>>>
 ```
+
+If you were to call this again after the ETag of the resource has changed, the new version would be downloaded
+and the local path returned from `cached_path()` would point to the newly downloaded version.
 
 ```{tip}
 There are multiple ways to [change the cache directory](#overriding-the-default-cache-directory).
-```
-
-If you were to call this again after the ETag of the resource has changed, a new version will be cached:
-
-```python
-path2 = cached_path("https://github.com/allenai/cached_path/blob/main/README.md")
-assert path2 != path
 ```
 
 ## Supported URL schemes
@@ -50,11 +47,12 @@ You can also overwrite how any of these schemes are handled or add clients for n
 {func}`~cached_path.cached_path()` will safely extract archives (`.tar.gz` or `.zip` files) if you set the `extract_archive` argument to `True`:
 
 ```python
-cached_archive = cached_path(
-    "https://github.com/allenai/cached_path/releases/download/v0.1.0/cached_path-0.1.0.tar.gz",
-    extract_archive=True,
-)
-assert os.path.isdir(cached_archive)
+>>> cached_archive = cached_path(
+...    "https://github.com/allenai/cached_path/releases/download/v0.1.0/cached_path-0.1.0.tar.gz",
+...    extract_archive=True,
+... )
+>>> assert cached_archive.is_dir()
+>>>
 ```
 
 This works for both local and remote resources.
@@ -63,11 +61,12 @@ You can also automatically get the path to a certain file or directory within an
 the relative path to the file within the archive to the string given to {func}`~cached_path.cached_path()`:
 
 ```python
-path = cached_path(
-    "https://github.com/allenai/cached_path/releases/download/v0.1.0/cached_path-0.1.0.tar.gz!README.md",
-    extract_archive=True,
-)
-assert os.path.isfile(path)
+>>> path = cached_path(
+...     "https://github.com/allenai/cached_path/releases/download/v0.1.0/cached_path-0.1.0.tar.gz!cached_path-0.1.0/README.md",
+...     extract_archive=True,
+... )
+>>> assert path.is_file()
+>>>
 ```
 
 ## Overriding the default cache directory

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = tests/
+testpaths = tests/ docs/source/
 python_classes = Test* *Test
 log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
 log_level = DEBUG


### PR DESCRIPTION
Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Changes the return type of `cached_path()` to `Path` instead of `str`.
- Tests examples in docs in CI.
- Adds a FAQ section to docs with a question and answer about async.