### PR TITLE
Fix and add test for ambiguous url error

### DIFF
--- a/cached_path/schemes/hf.py
+++ b/cached_path/schemes/hf.py
@@ -82,7 +82,7 @@ def hf_get_from_cache(url: str, cache_dir: PathOrStr) -> Path:
             model_identifier, filename = identifier.split("/")
             return hf_hub_download(url, model_identifier, filename, cache_dir)
         except requests.exceptions.HTTPError as exc:
-            if exc.response.status_code == 404 or exc.response.status_code == 401:
+            if exc.response.status_code in {401, 404}:
                 return hf_hub_download(url, identifier, None, cache_dir)
             raise
         except ValueError:

--- a/cached_path/schemes/hf.py
+++ b/cached_path/schemes/hf.py
@@ -77,12 +77,12 @@ def hf_get_from_cache(url: str, cache_dir: PathOrStr) -> Path:
         # because this could refer to either:
         #  1. the file 'yyyy' in the 'xxxx' repository, or
         #  2. the repo 'yyyy' under the user/org name 'xxxx'.
-        # We default to (1), but if we get a 404 error then we try (2).
+        # We default to (1), but if we get a 404 error or 401 error then we try (2)
         try:
             model_identifier, filename = identifier.split("/")
             return hf_hub_download(url, model_identifier, filename, cache_dir)
         except requests.exceptions.HTTPError as exc:
-            if exc.response.status_code == 404:
+            if exc.response.status_code == 404 or exc.response.status_code == 401:
                 return hf_hub_download(url, identifier, None, cache_dir)
             raise
         except ValueError:

--- a/tests/cached_path_test.py
+++ b/tests/cached_path_test.py
@@ -375,3 +375,15 @@ class TestCachedPathHf(BaseTestClass):
         assert path.is_dir()
         meta = Meta.from_path(_meta_file_path(path))
         assert meta.resource == f"hf://{model_name}"
+
+    def test_snapshot_download_ambiguous_url(self):
+        # URLs like 'hf://xxxx/yyyy' are potentially ambiguous,
+        # because this could refer to either:
+        #  1. the file 'yyyy' in the 'xxxx' repository, or
+        #  2. the repo 'yyyy' under the user/org name 'xxxx'.
+        # We default to (1), but if we get a 404 error or 401 error then we try (2).
+        model_name = "lysandre/test-simple-tagger-tiny"
+        path = cached_path(f"hf://{model_name}")  # should resolve to option 2.
+        assert path.is_dir()
+        meta = Meta.from_path(_meta_file_path(path))
+        assert meta.resource == f"hf://{model_name}"


### PR DESCRIPTION
The issue is, we now get a 401 first if we're not logged in, and _then_ get 404 after logging in. 