### PR TITLE
upgrade deps, improve HF downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Downloads from HuggingFace will be passed onto the `huggingface_hub` library completely so you won't end up with duplicates of the same objects if your using other libraries that use `huggingface_hub` directly, such as `transformers`.
+
 ## [v1.1.6](https://github.com/allenai/cached_path/releases/tag/v1.1.6) - 2022-09-28
 
 ### Changed

--- a/cached_path/__init__.py
+++ b/cached_path/__init__.py
@@ -21,3 +21,17 @@ from .util import (
     is_url_or_existing_file,
     resource_to_filename,
 )
+
+__all__ = [
+    "cached_path",
+    "get_cache_dir",
+    "set_cache_dir",
+    "get_download_progress",
+    "SchemeClient",
+    "add_scheme_client",
+    "check_tarfile",
+    "filename_to_url",
+    "find_latest_cached",
+    "is_url_or_existing_file",
+    "resource_to_filename",
+]

--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -128,9 +128,6 @@ def cached_path(
         the resource.
 
     """
-    cache_dir = Path(cache_dir if cache_dir else get_cache_dir()).expanduser()
-    cache_dir.mkdir(parents=True, exist_ok=True)
-
     if not isinstance(url_or_filename, str):
         url_or_filename = str(url_or_filename)
 
@@ -179,6 +176,8 @@ def cached_path(
 
     else:
         url_or_filename = Path(url_or_filename).expanduser()
+        cache_dir = Path(cache_dir if cache_dir else get_cache_dir()).expanduser()
+        cache_dir.mkdir(parents=True, exist_ok=True)
 
         if url_or_filename.exists():
             # File, and it exists.
@@ -272,10 +271,11 @@ def get_from_cache(
     Given a URL, look for the corresponding dataset in the local cache.
     If it's not there, download it. Then return the path to the cached file and the ETag.
     """
-    cache_dir = Path(cache_dir if cache_dir else get_cache_dir())
-
     if url.startswith("hf://"):
         return hf_get_from_cache(url, cache_dir), None
+
+    cache_dir = Path(cache_dir if cache_dir else get_cache_dir()).expanduser()
+    cache_dir.mkdir(parents=True, exist_ok=True)
 
     client = get_scheme_client(url)
 

--- a/cached_path/schemes/hf.py
+++ b/cached_path/schemes/hf.py
@@ -17,14 +17,11 @@ from huggingface_hub.utils import (
 )
 
 from cached_path.common import PathOrStr
-from cached_path.file_lock import FileLock
-from cached_path.meta import Meta
-from cached_path.util import _lock_file_path, _meta_file_path
 from cached_path.version import VERSION
 
 
 def hf_hub_download(
-    url: str, model_identifier: str, filename: Optional[str], cache_dir: PathOrStr
+    model_identifier: str, filename: Optional[str], cache_dir: Optional[PathOrStr] = None
 ) -> Path:
     revision: Optional[str]
     if "@" in model_identifier:
@@ -34,49 +31,33 @@ def hf_hub_download(
         repo_id = model_identifier
         revision = None
 
-    cache_path: Path
     if filename is not None:
-        hub_url = hf_hub.hf_hub_url(repo_id=repo_id, filename=filename, revision=revision)
-        cache_path = Path(
-            hf_hub.cached_download(
-                url=hub_url,
+        return Path(
+            hf_hub.hf_hub_download(
+                repo_id=repo_id,
+                filename=filename,
+                revision=revision,
                 library_name="cached_path",
                 library_version=VERSION,
                 cache_dir=cache_dir,
             )
         )
-        # HF writes it's own meta '.json' file which uses the same format we used to use and still
-        # support, but is missing some fields that we like to have.
-        # So we overwrite it when it we can.
-        with FileLock(_lock_file_path(cache_path), read_only_ok=True):
-            meta = Meta.from_path(_meta_file_path(cache_path))
-            # The file HF writes will have 'resource' set to the 'http' URL corresponding to the 'hf://' URL,
-            # but we want 'resource' to be the original 'hf://' URL.
-            if meta.resource != url:
-                meta.resource = url
-                meta.to_file()
     else:
-        cache_path = Path(hf_hub.snapshot_download(repo_id, revision=revision, cache_dir=cache_dir))
-        # Need to write the meta file for snapshot downloads if it doesn't exist.
-        with FileLock(_lock_file_path(cache_path), read_only_ok=True):
-            if not _meta_file_path(cache_path).is_file():
-                meta = Meta.new(
-                    url,
-                    cache_path,
-                    extraction_dir=True,
-                )
-                meta.to_file()
-    return cache_path
+        return Path(hf_hub.snapshot_download(repo_id, revision=revision, cache_dir=cache_dir))
 
 
-def hf_get_from_cache(url: str, cache_dir: PathOrStr) -> Path:
+def hf_get_from_cache(url: str, cache_dir: Optional[PathOrStr] = None) -> Path:
+    if cache_dir is not None:
+        cache_dir = Path(cache_dir).expanduser()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
     # Remove the 'hf://' prefix
     identifier = url[5:]
 
     if identifier.count("/") > 1:
         filename = "/".join(identifier.split("/")[2:])
         model_identifier = "/".join(identifier.split("/")[:2])
-        return hf_hub_download(url, model_identifier, filename, cache_dir)
+        return hf_hub_download(model_identifier, filename, cache_dir)
     elif identifier.count("/") == 1:
         # 'hf://' URLs like 'hf://xxxx/yyyy' are potentially ambiguous,
         # because this could refer to either:
@@ -85,15 +66,15 @@ def hf_get_from_cache(url: str, cache_dir: PathOrStr) -> Path:
         # We default to (1), but if we get a 404 error or 401 error then we try (2)
         try:
             model_identifier, filename = identifier.split("/")
-            return hf_hub_download(url, model_identifier, filename, cache_dir)
+            return hf_hub_download(model_identifier, filename, cache_dir)
         except (RepositoryNotFoundError, RevisionNotFoundError, EntryNotFoundError):
-            return hf_hub_download(url, identifier, None, cache_dir)
+            return hf_hub_download(identifier, None, cache_dir)
         except requests.exceptions.HTTPError as exc:
             if exc.response is not None and exc.response.status_code in {401, 404}:
-                return hf_hub_download(url, identifier, None, cache_dir)
+                return hf_hub_download(identifier, None, cache_dir)
             else:
                 raise
         except ValueError:
-            return hf_hub_download(url, identifier, None, cache_dir)
+            return hf_hub_download(identifier, None, cache_dir)
     else:
-        return hf_hub_download(url, identifier, None, cache_dir)
+        return hf_hub_download(identifier, None, cache_dir)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,8 @@ flake8
 mypy==0.991
 
 # Automatic code formatting
-black==22.10.0
-isort==5.10.1
+black==22.12.0
+isort==5.11.4
 
 # Running tests.
 pytest
@@ -33,7 +33,7 @@ responses==0.21.0
 Sphinx==5.3.0
 
 # Sphinx theme: https://sphinx-themes.org/sample-sites/furo/
-furo==2022.9.29
+furo==2022.12.7
 
 # Lets Sphinx parse markdown files in addition to rst.
 myst-parser==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.0,<3.0
-rich>=12.1,<13.0
-filelock>=3.4,<3.9
+rich>=12.1,<14.0
+filelock>=3.4,<3.10
 boto3>=1.0,<2.0
 google-cloud-storage>=1.32.0,<3.0
 huggingface-hub>=0.8.1,<0.12.0

--- a/tests/cached_path_test.py
+++ b/tests/cached_path_test.py
@@ -360,7 +360,7 @@ class TestCachedPathS3(BaseTestClass):
 class TestCachedPathHf(BaseTestClass):
     @flaky
     def test_cached_download_no_user_or_org(self):
-        path = cached_path("hf://t5-small/config.json")
+        path = cached_path("hf://t5-small/config.json", cache_dir=self.TEST_DIR)
         assert path.is_file()
         assert self.TEST_DIR in path.parents
 
@@ -368,7 +368,7 @@ class TestCachedPathHf(BaseTestClass):
     def test_snapshot_download_no_user_or_org(self):
         # This is the smallest snapshot I could find that is not associated with a user / org.
         model_name = "distilbert-base-german-cased"
-        path = cached_path(f"hf://{model_name}")
+        path = cached_path(f"hf://{model_name}", cache_dir=self.TEST_DIR)
         assert path.is_dir()
         assert self.TEST_DIR in path.parents
 
@@ -379,6 +379,8 @@ class TestCachedPathHf(BaseTestClass):
         #  2. the repo 'yyyy' under the user/org name 'xxxx'.
         # We default to (1), but if we get a 404 error or 401 error then we try (2).
         model_name = "lysandre/test-simple-tagger-tiny"
-        path = cached_path(f"hf://{model_name}")  # should resolve to option 2.
+        path = cached_path(
+            f"hf://{model_name}", cache_dir=self.TEST_DIR
+        )  # should resolve to option 2.
         assert path.is_dir()
         assert self.TEST_DIR in path.parents

--- a/tests/cached_path_test.py
+++ b/tests/cached_path_test.py
@@ -362,10 +362,7 @@ class TestCachedPathHf(BaseTestClass):
     def test_cached_download_no_user_or_org(self):
         path = cached_path("hf://t5-small/config.json")
         assert path.is_file()
-        assert path.parent == self.TEST_DIR
-        meta = Meta.from_path(_meta_file_path(path))
-        assert meta.etag is not None
-        assert meta.resource == "hf://t5-small/config.json"
+        assert self.TEST_DIR in path.parents
 
     @flaky
     def test_snapshot_download_no_user_or_org(self):
@@ -373,8 +370,7 @@ class TestCachedPathHf(BaseTestClass):
         model_name = "distilbert-base-german-cased"
         path = cached_path(f"hf://{model_name}")
         assert path.is_dir()
-        meta = Meta.from_path(_meta_file_path(path))
-        assert meta.resource == f"hf://{model_name}"
+        assert self.TEST_DIR in path.parents
 
     def test_snapshot_download_ambiguous_url(self):
         # URLs like 'hf://xxxx/yyyy' are potentially ambiguous,
@@ -385,5 +381,4 @@ class TestCachedPathHf(BaseTestClass):
         model_name = "lysandre/test-simple-tagger-tiny"
         path = cached_path(f"hf://{model_name}")  # should resolve to option 2.
         assert path.is_dir()
-        meta = Meta.from_path(_meta_file_path(path))
-        assert meta.resource == f"hf://{model_name}"
+        assert self.TEST_DIR in path.parents

--- a/tests/schemes_test.py
+++ b/tests/schemes_test.py
@@ -17,6 +17,9 @@ class CustomSchemeClient(SchemeClient):
     def get_etag(self):
         return "AAA"
 
+    def get_size(self):
+        return None
+
     def get_resource(self, temp_file):
         pass
 


### PR DESCRIPTION
General dependency upgrades and improve how we download resources from HF hub. Now we just delegate the to `huggingface_hub` completely so that if you don't end up with duplicate downloads of the same objects from HF.