### PR TITLE
Updated huggingface-hub version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "filelock>=3.4,<3.14",
     "boto3>=1.0,<2.0",
     "google-cloud-storage>=1.32.0,<3.0",
-    "huggingface-hub>=0.8.1,<0.22.0",
+    "huggingface-hub>=0.8.1,<=0.23.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Facing build dependancy issues with the latest version of `transformers` as shown below: 

![image](https://github.com/allenai/cached_path/assets/42506819/c11491d3-5c57-463a-8c2c-11502ec1be03)

Retrying with my fork with updated version fixed the conflict, hoping the rest of the codebase works too!