### PR TITLE
Cache GCS client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
         task:
           - name: Test
             run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Loosened `filelock` dependency.
+- Fixed issue where making too many calls to Google Cloud Storage causes `Compute Engine Metadata server unavailable` error 
 
 ## [v1.6.4](https://github.com/allenai/cached_path/releases/tag/v1.6.4) - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.6.5](https://github.com/allenai/cached_path/releases/tag/v1.6.5) - 2024-12-09
 
+### Added
+
+- Caching of S3, R2 and GCS cloud storage clients, for better multi-threading support.
+
 ### Fixed
 
 - Loosened `filelock` dependency.
-- Fixed issue where making too many calls to Google Cloud Storage causes `Compute Engine Metadata server unavailable` error 
+- Fixed issue where making too many calls to Google Cloud Storage causes `Compute Engine Metadata server unavailable` error.
 
 ## [v1.6.4](https://github.com/allenai/cached_path/releases/tag/v1.6.4) - 2024-11-20
 

--- a/cached_path/schemes/gs.py
+++ b/cached_path/schemes/gs.py
@@ -2,6 +2,7 @@
 Google Cloud Storage.
 """
 
+from functools import cache
 import io
 from typing import Optional, Tuple
 
@@ -53,11 +54,18 @@ class GsClient(SchemeClient):
 
     @staticmethod
     def get_gcs_blob(resource: str) -> Blob:
-        try:
-            gcs_resource = storage.Client()
-        except DefaultCredentialsError:
-            gcs_resource = storage.Client.create_anonymous_client()
+        gcs_client = _get_gcs_client()
         bucket_name, gcs_path = GsClient.split_gcs_path(resource)
-        bucket = gcs_resource.bucket(bucket_name)
+        bucket = gcs_client.bucket(bucket_name)
         blob = bucket.blob(gcs_path)
         return blob
+
+
+@cache
+def _get_gcs_client():
+    try:
+        client = storage.Client()
+    except DefaultCredentialsError:
+        client = storage.Client.create_anonymous_client()
+
+    return client

--- a/cached_path/schemes/gs.py
+++ b/cached_path/schemes/gs.py
@@ -29,8 +29,8 @@ class GsClient(SchemeClient):
             try:
                 self.blob.reload()
                 self._loaded = True
-            except NotFound:
-                raise FileNotFoundError(self.resource)
+            except NotFound as exc:
+                raise FileNotFoundError(self.resource) from exc
 
     def get_etag(self) -> Optional[str]:
         self.load()
@@ -62,7 +62,7 @@ class GsClient(SchemeClient):
 
 
 @cache
-def _get_gcs_client():
+def _get_gcs_client() -> storage.Client:
     try:
         client = storage.Client()
     except DefaultCredentialsError:

--- a/cached_path/schemes/gs.py
+++ b/cached_path/schemes/gs.py
@@ -2,8 +2,8 @@
 Google Cloud Storage.
 """
 
-from functools import cache
 import io
+from functools import cache
 from typing import Optional, Tuple
 
 from google.api_core.exceptions import NotFound

--- a/cached_path/schemes/r2.py
+++ b/cached_path/schemes/r2.py
@@ -4,6 +4,7 @@ Cloudflare R2.
 
 import io
 import os
+from functools import cache
 from typing import Optional
 
 import boto3.dynamodb
@@ -27,36 +28,7 @@ class R2Client(SchemeClient):
         SchemeClient.__init__(self, resource)
         self.bucket_name, self.path = _split_cloud_path(resource, "r2")
 
-        # find credentials
-        endpoint_url = os.environ.get("R2_ENDPOINT_URL")
-        if endpoint_url is None:
-            raise ValueError(
-                "R2 endpoint url is not set. Did you forget to set the 'R2_ENDPOINT_URL' env var?"
-            )
-        profile_name = os.environ.get("R2_PROFILE")
-        access_key_id = os.environ.get("R2_ACCESS_KEY_ID")
-        secret_access_key = os.environ.get("R2_SECRET_ACCESS_KEY")
-        if access_key_id is not None and secret_access_key is not None:
-            session_kwargs = {
-                "aws_access_key_id": access_key_id,
-                "aws_secret_access_key": secret_access_key,
-            }
-        elif profile_name is not None:
-            session_kwargs = {"profile_name": profile_name}
-        else:
-            raise ValueError(
-                "To authenticate for R2, you either have to set the 'R2_PROFILE' env var and set up this profile, "
-                "or set R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY."
-            )
-
-        s3_session = boto3.session.Session(**session_kwargs)
-
-        self.s3 = s3_session.client(
-            service_name="s3",
-            endpoint_url=endpoint_url,
-            region_name="auto",
-            config=Config(retries={"max_attempts": 10, "mode": "standard"}),
-        )
+        self.s3 = _get_s3_resource_client()
         self.object_info = None
 
     def _ensure_object_info(self):
@@ -88,3 +60,36 @@ class R2Client(SchemeClient):
             Bucket=self.bucket_name, Key=self.path, Range=f"bytes={index}-{index+length-1}"
         )
         return response["Body"].read()
+
+
+@cache
+def _get_s3_resource_client():
+    # find credentials
+    endpoint_url = os.environ.get("R2_ENDPOINT_URL")
+    if endpoint_url is None:
+        raise ValueError(
+            "R2 endpoint url is not set. Did you forget to set the 'R2_ENDPOINT_URL' env var?"
+        )
+    profile_name = os.environ.get("R2_PROFILE")
+    access_key_id = os.environ.get("R2_ACCESS_KEY_ID")
+    secret_access_key = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if access_key_id is not None and secret_access_key is not None:
+        session_kwargs = {
+            "aws_access_key_id": access_key_id,
+            "aws_secret_access_key": secret_access_key,
+        }
+    elif profile_name is not None:
+        session_kwargs = {"profile_name": profile_name}
+    else:
+        raise ValueError(
+            "To authenticate for R2, you either have to set the 'R2_PROFILE' env var and set up this profile, "
+            "or set R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY."
+        )
+
+    s3_session = boto3.session.Session(**session_kwargs)
+    return s3_session.client(
+        service_name="s3",
+        endpoint_url=endpoint_url,
+        region_name="auto",
+        config=Config(retries={"max_attempts": 10, "mode": "standard"}),
+    )


### PR DESCRIPTION
A new GCS client is created each time a `cached_path` call is made to GCS. Making too many of them seems to cause `Compute Engine Metadata server unavailable` error and timeouts. Thus, this change caches the client.