### PR TITLE
add symlink flag

### DIFF
--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import urlparse
+import fastzipfile
 from zipfile import ZipFile, is_zipfile
 
 from .cache_file import CacheFile
@@ -71,6 +72,7 @@ def cached_path(
     quiet: bool = False,
     progress: Optional["Progress"] = None,
     symlink: bool = False,
+    zip_pwd: Optional[str] = None,
 ) -> Path:
     """
     Given something that might be a URL or local path, determine which.
@@ -193,6 +195,8 @@ def cached_path(
             force_extract=force_extract,
             quiet=quiet,
             progress=progress,
+            symlink=False,
+            zip_pwd=zip_pwd,
         )
         if not cached_archive_path.is_dir():
             raise ValueError(
@@ -299,7 +303,7 @@ def cached_path(
                             shutil.copyfileobj(bz2_file, out_file)
                 else:
                     with ZipFile(file_path) as zip_file:
-                        zip_file.extractall(tmp_extraction_dir)
+                        zip_file.extractall(tmp_extraction_dir, pwd=zip_pwd.encode() if zip_pwd else None)
                 # Extraction was successful, rename temp directory to final
                 # cache directory and dump the meta data.
                 os.replace(tmp_extraction_dir, extraction_path)

--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -251,20 +251,10 @@ def cached_path(
             raise ValueError(f"unable to parse {orig_url_or_filename} as a URL or as a local path")
 
     if extraction_path is not None:
-        def _get_bz2_extract_symlink():
-            assert _is_bz2file(url_or_filename)
-            symlink_dir = file_path.parent / (file_path.name + "-symlink")
-            symlink_dir.mkdir(exist_ok=True)
-            meta = Meta.from_path(str(file_path) + ".json")
-            symlink_path = symlink_dir / Path(meta.resource).name[:-4]
-            if not symlink_path.exists():
-                symlink_path.symlink_to(extraction_path/Path(meta.resource).name[:-4])
-            return symlink_path
+        assert not symlink
         # If the extracted directory already exists (and is non-empty), then no
         # need to create a lock file and extract again unless `force_extract=True`.
         if os.path.isdir(extraction_path) and os.listdir(extraction_path) and not force_extract:
-            if symlink:
-                return _get_bz2_extract_symlink()
             return extraction_path
 
         # Extract it.
@@ -317,8 +307,8 @@ def cached_path(
             finally:
                 shutil.rmtree(tmp_extraction_dir, ignore_errors=True)
 
-        if symlink:
-            return _get_bz2_extract_symlink()
+        if _is_bz2file(url_or_filename):
+            return extraction_path / Path(url_or_filename).name[:-4]
         return extraction_path
 
     if symlink:

--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -64,6 +64,7 @@ def cached_path(
     force_extract: bool = False,
     quiet: bool = False,
     progress: Optional["Progress"] = None,
+    symlink: bool = False,
 ) -> Path:
     """
     Given something that might be a URL or local path, determine which.
@@ -142,6 +143,9 @@ def cached_path(
     progress :
         A custom progress display to use. If not set and ``quiet=False``, a default display
         from :func:`~cached_path.get_download_progress()` will be used.
+
+    symlink :
+        If ``True``, create a symlink to the cached file with the original file name.
 
     Returns
     -------
@@ -289,6 +293,15 @@ def cached_path(
                 shutil.rmtree(tmp_extraction_dir, ignore_errors=True)
 
         return extraction_path
+
+    if symlink:
+        symlink_dir = file_path.parent / (file_path.name + "-symlink")
+        symlink_dir.mkdir(exist_ok=True)
+        meta = Meta.from_path(str(file_path) + ".json")
+        symlink_path = symlink_dir / Path(meta.resource).name
+        if not symlink_path.exists():
+            symlink_path.symlink_to(file_path)
+        return symlink_path
 
     return file_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "boto3>=1.0,<2.0",
     "google-cloud-storage>=1.32.0,<3.0",
     "huggingface-hub>=0.8.1,<0.28.0",
+    "fastzipfile>=2.3.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Sometimes we expect file paths to have specific file names or extensions, so having a symlink with the original file name to the cached file would be handy.