### PR TITLE
Features custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `headers` option for passing custom headers to HTTP requests.
+
 ## [v1.6.7](https://github.com/allenai/cached_path/releases/tag/v1.6.7) - 2025-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ returning the local path to the specific file. For example:
 cached_path("model.tar.gz!weights.th", extract_archive=True)
 ```
 
+### Using custom headers for HTTP requests
+
+You can provide custom headers for HTTP requests, which is useful for accessing private resources that require authentication:
+
+```python
+# Using an API token for private resources (e.g. Hugging Face)
+headers = {"Authorization": f"Bearer {hf_token}"}
+cached_path("https://huggingface.co/api/models/private-model/resolve/main/model.bin", headers=headers)
+```
+
+This is particularly useful for downloading private files from services like Hugging Face, GitHub, or any other API that uses Bearer token authentication.
+
 ### Cache directory
 
 By default the cache directory is `~/.cache/cached_path/`, however there are several ways to override this setting:

--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -202,7 +202,9 @@ def cached_path(
 
     if parsed.scheme in get_supported_schemes():
         # URL, so get it from the cache (downloading if necessary)
-        file_path, etag = get_from_cache(url_or_filename, cache_dir, quiet=quiet, progress=progress)
+        file_path, etag = get_from_cache(
+            url_or_filename, cache_dir, quiet=quiet, progress=progress, headers=headers
+        )
 
         if extract_archive and _is_archive(file_path, url_or_filename):
             # This is the path the file should be extracted to.

--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -50,7 +50,11 @@ def _is_rarfile(path: PathOrStr, url_or_filename: PathOrStr) -> bool:
 
 
 def _is_archive(file_path: PathOrStr, url_or_filename) -> bool:
-    return is_zipfile(file_path) or tarfile.is_tarfile(file_path) or _is_rarfile(file_path, url_or_filename)
+    return (
+        is_zipfile(file_path)
+        or tarfile.is_tarfile(file_path)
+        or _is_rarfile(file_path, url_or_filename)
+    )
 
 
 def cached_path(
@@ -188,7 +192,9 @@ def cached_path(
             headers=headers,
         )
         if not cached_archive_path.is_dir():
-            raise ValueError(f"{url_or_filename} uses the ! syntax, but does not specify an archive file.")
+            raise ValueError(
+                f"{url_or_filename} uses the ! syntax, but does not specify an archive file."
+            )
 
         # Now return the full path to the desired file within the extracted archive,
         # provided it exists.
@@ -228,7 +234,8 @@ def cached_path(
                 # The name of the directory is a hash of the resource file path and it's modification
                 # time. That way, if the file changes, we'll know when to extract it again.
                 extraction_name = (
-                    resource_to_filename(url_or_filename, str(os.path.getmtime(file_path))) + "-extracted"
+                    resource_to_filename(url_or_filename, str(os.path.getmtime(file_path)))
+                    + "-extracted"
                 )
                 extraction_path = cache_dir / extraction_name
         elif parsed.scheme == "":

--- a/cached_path/schemes/__init__.py
+++ b/cached_path/schemes/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Optional, Set, Type
 
 from .gs import GsClient
@@ -18,6 +19,8 @@ except (ImportError, ModuleNotFoundError):
 
 
 _SCHEME_TO_CLIENT = {}
+
+logger = logging.getLogger(__name__)
 
 
 def add_scheme_client(client: Type[SchemeClient]) -> None:
@@ -64,9 +67,12 @@ def get_scheme_client(resource: str, headers: Optional[Dict[str, str]] = None) -
     maybe_scheme = resource.split("://")[0]
     client_cls = _SCHEME_TO_CLIENT.get(maybe_scheme, HttpClient)
 
-    # Only pass headers to HttpClient
-    if client_cls == HttpClient and headers:
-        return client_cls(resource, headers=headers)
+    if headers:
+        if client_cls == HttpClient:
+            return client_cls(resource, headers=headers)
+        else:
+            msg = f"Headers are only supported for HTTP/HTTPS resources, got {client_cls}"
+            logger.warning(msg)
 
     return client_cls(resource)
 

--- a/cached_path/schemes/__init__.py
+++ b/cached_path/schemes/__init__.py
@@ -1,4 +1,4 @@
-from typing import Set, Type
+from typing import Dict, Optional, Set, Type
 
 from .gs import GsClient
 from .hf import hf_get_from_cache
@@ -43,12 +43,32 @@ if BeakerClient is not None:
     add_scheme_client(BeakerClient)
 
 
-def get_scheme_client(resource: str) -> SchemeClient:
+def get_scheme_client(resource: str, headers: Optional[Dict[str, str]] = None) -> SchemeClient:
     """
     Get the right client for the given resource.
+
+    Parameters
+    ----------
+    resource : str
+        The URL or path to the resource.
+    headers : Optional[Dict[str, str]], optional
+        Custom headers to add to HTTP requests, by default None.
+        Example: {"Authorization": "Bearer YOUR_TOKEN"} for private resources.
+        Only used for HTTP/HTTPS resources.
+
+    Returns
+    -------
+    SchemeClient
+        The appropriate client for the resource.
     """
     maybe_scheme = resource.split("://")[0]
-    return _SCHEME_TO_CLIENT.get(maybe_scheme, HttpClient)(resource)
+    client_cls = _SCHEME_TO_CLIENT.get(maybe_scheme, HttpClient)
+
+    # Only pass headers to HttpClient
+    if client_cls == HttpClient and headers:
+        return client_cls(resource, headers=headers)
+
+    return client_cls(resource)
 
 
 def get_supported_schemes() -> Set[str]:

--- a/cached_path/schemes/__init__.py
+++ b/cached_path/schemes/__init__.py
@@ -68,7 +68,7 @@ def get_scheme_client(resource: str, headers: Optional[Dict[str, str]] = None) -
     client_cls = _SCHEME_TO_CLIENT.get(maybe_scheme, HttpClient)
 
     if headers:
-        if client_cls == HttpClient:
+        if isinstance(client_cls, HttpClient):
             return client_cls(resource, headers=headers)
         else:
             msg = f"Headers are only supported for HTTP/HTTPS resources, got {client_cls.__name__}"

--- a/cached_path/schemes/__init__.py
+++ b/cached_path/schemes/__init__.py
@@ -71,7 +71,7 @@ def get_scheme_client(resource: str, headers: Optional[Dict[str, str]] = None) -
         if client_cls == HttpClient:
             return client_cls(resource, headers=headers)
         else:
-            msg = f"Headers are only supported for HTTP/HTTPS resources, got {client_cls}"
+            msg = f"Headers are only supported for HTTP/HTTPS resources, got {client_cls.__name__}"
             logger.warning(msg)
 
     return client_cls(resource)

--- a/cached_path/schemes/http.py
+++ b/cached_path/schemes/http.py
@@ -1,5 +1,5 @@
 import io
-from typing import Optional
+from typing import Dict, Optional
 
 import requests  # type: ignore[import-untyped]
 from requests.adapters import HTTPAdapter  # type: ignore[import-untyped]
@@ -17,18 +17,28 @@ class RecoverableServerError(requests.exceptions.HTTPError):
     """
 
 
-def session_with_backoff() -> requests.Session:
+def session_with_backoff(headers: Optional[Dict[str, str]] = None) -> requests.Session:
     """
     We ran into an issue where http requests to s3 were timing out,
     possibly because we were making too many requests too quickly.
     This helper function returns a requests session that has retry-with-backoff
     built in. See
     <https://stackoverflow.com/questions/23267409/how-to-implement-retry-mechanism-into-python-requests-library>.
+
+    Parameters
+    ----------
+    headers : Optional[Dict[str, str]], optional
+        Custom headers to add to all requests, by default None
     """
     session = requests.Session()
     retries = Retry(total=5, backoff_factor=1, status_forcelist=RECOVERABLE_SERVER_ERROR_CODES)
     session.mount("http://", HTTPAdapter(max_retries=retries))
     session.mount("https://", HTTPAdapter(max_retries=retries))
+
+    # Add custom headers if provided
+    if headers:
+        session.headers.update(headers)
+
     return session
 
 
@@ -36,15 +46,27 @@ class HttpClient(SchemeClient):
     scheme = ("http", "https")
     recoverable_errors = SchemeClient.recoverable_errors + (RecoverableServerError,)
 
-    def __init__(self, resource: str) -> None:
+    def __init__(self, resource: str, headers: Optional[Dict[str, str]] = None) -> None:
+        """
+        Initialize an HTTP client for the given resource.
+
+        Parameters
+        ----------
+        resource : str
+            The URL to the resource.
+        headers : Optional[Dict[str, str]], optional
+            Custom headers to add to all requests, by default None.
+            Example: {"Authorization": "Bearer YOUR_TOKEN"} for private resources.
+        """
         super().__init__(resource)
         self._head_response = None
+        self.headers = headers or {}
 
     @property
     def head_response(self):
         if self._head_response is None:
             try:
-                with session_with_backoff() as session:
+                with session_with_backoff(self.headers) as session:
                     response = session.head(self.resource, allow_redirects=True)
             except MaxRetryError as e:
                 raise RecoverableServerError(e.reason)
@@ -62,7 +84,7 @@ class HttpClient(SchemeClient):
         return None if content_length is None else int(content_length)
 
     def get_resource(self, temp_file: io.BufferedWriter) -> None:
-        with session_with_backoff() as session:
+        with session_with_backoff(self.headers) as session:
             try:
                 response = session.get(self.resource, stream=True)
             except MaxRetryError as e:


### PR DESCRIPTION
Header can now be pass to cached_path and will be forward down to the http session.

Here is an example usage with huggingface:
```python
from cached_path import cached_path

HF_TOKEN = ...
headers = {"Authorization": f"Bearer {HF_TOKEN}"}

cached_path(
"https://huggingface.co/datasets/.../resolve/main/.../....zip",
headers=headers
)
```