### PR TITLE
Update rich dependency version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.9"
 dependencies = [
     "requests",
-    "rich>=12.1,<14.0",
+    "rich>=12.1,<16.0",
     "filelock>=3.4,<4.0",
     "boto3>=1.0,<2.0",
     "google-cloud-storage>=1.32.0,<4.0",


### PR DESCRIPTION
Hi this small PR aims to solve #263 by simply relaxing the rich dependency range considering the only breaking change is python 3.8. Tested locally with Molmobot and did not introduce any issue