### PR TITLE
Reject unsafe ZIP archive members

### DIFF
--- a/cached_path/_cached_path.py
+++ b/cached_path/_cached_path.py
@@ -22,6 +22,7 @@ from .util import (
     _lock_file_path,
     _meta_file_path,
     check_tarfile,
+    check_zipfile,
     find_latest_cached,
     resource_to_filename,
 )
@@ -283,6 +284,7 @@ def cached_path(
                         rar_file.extractall(tmp_extraction_dir)
                 else:
                     with ZipFile(file_path) as zip_file:
+                        check_zipfile(zip_file)
                         zip_file.extractall(tmp_extraction_dir)
                 # Extraction was successful, rename temp directory to final
                 # cache directory and dump the meta data.

--- a/cached_path/util.py
+++ b/cached_path/util.py
@@ -1,9 +1,10 @@
 import os
 import tarfile
 from hashlib import sha256
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
+from zipfile import ZipFile
 
 from .common import PathOrStr, get_cache_dir
 from .meta import Meta
@@ -114,6 +115,29 @@ def check_tarfile(tar_file: tarfile.TarFile):
                     f"Tar file {str(tar_file.name)} is trying to link to a file "
                     "outside of its extraction directory."
                 )
+
+
+def _check_archive_member_path(member_name: str, archive_type: str, archive_name: str):
+    posix_path = PurePosixPath(member_name)
+    windows_path = PureWindowsPath(member_name)
+
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    ):
+        raise ValueError(
+            f"{archive_type} {archive_name} is trying to create a file outside of its extraction directory."
+        )
+
+
+def check_zipfile(zip_file: ZipFile):
+    """Zip files should not be able to write outside the extraction directory."""
+    archive_name = str(zip_file.filename)
+    for zip_info in zip_file.infolist():
+        _check_archive_member_path(zip_info.filename, "Zip file", archive_name)
 
 
 def is_url_or_existing_file(url_or_filename: PathOrStr) -> bool:

--- a/tests/cached_path_test.py
+++ b/tests/cached_path_test.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from collections import Counter
 from pathlib import Path
+from zipfile import ZipFile
 
 import packaging.version
 import pytest
@@ -265,6 +266,17 @@ class TestCachedPathWithArchive(BaseTestClass):
 
     def test_extract_with_external_symlink(self):
         dangerous_file = self.FIXTURES_ROOT / "common" / "external_symlink.tar.gz"
+        with pytest.raises(ValueError):
+            cached_path(dangerous_file, extract_archive=True)
+
+    @pytest.mark.parametrize(
+        "member_name", ["../escape.txt", "..\\escape.txt", "/escape.txt", "C:/escape.txt"]
+    )
+    def test_extract_rejects_unsafe_zip_member_path(self, member_name: str):
+        dangerous_file = self.TEST_DIR / "unsafe.zip"
+        with ZipFile(dangerous_file, "w") as zip_file:
+            zip_file.writestr(member_name, "bad")
+
         with pytest.raises(ValueError):
             cached_path(dangerous_file, extract_archive=True)
 


### PR DESCRIPTION
## Summary
- validate ZIP member paths before extracting cached archives
- reject parent traversal, absolute paths, and Windows drive paths
- keep existing valid local and remote ZIP extraction behavior covered

## Tests
- uv run --extra dev pytest -q
- uv run --extra dev pytest tests/cached_path_test.py::TestCachedPathWithArchive -q
- uv run --extra dev ruff check cached_path/_cached_path.py cached_path/util.py tests/cached_path_test.py
- uv run --extra dev black --check cached_path/_cached_path.py cached_path/util.py tests/cached_path_test.py